### PR TITLE
typos in README + add std=c++11 option to avoid error about 'auto'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ src/tinyxml/tinyxmlparser.o
 # options
 DEFS=-DTARGET_UNIX
 INCLUDE=-Isdk
-CFLAGS=-O3 -g0 -Wall $(DEFS) $(INCLUDE) $(ADDFLAGS)
+CFLAGS=-O3 -g0 -Wall -std=c++11 $(DEFS) $(INCLUDE) $(ADDFLAGS)
 LFLAGS=-g3 
 PROJ=bin/Protoc
 

--- a/README
+++ b/README
@@ -1,11 +1,11 @@
-﻿Protoc is context and type free protocol compiler, data serizlizer and deserializer based on XML declarations and code snippets.
+﻿Protoc is context and type free protocol compiler, data serializer and deserializer based on XML declarations and code snippets.
 
 About
 -----
 
 Workset consists of two XML files - data schema and code snippets.
 First XML file declares data formats using simple syntax (let's call it "schema"). 
-Second XML file defines code snippets (let's call it "snippets") used to create global data parser with serializer and deserizlizer pair for each data type.
+Second XML file defines code snippets (let's call it "snippets") used to create global data parser with serializer and deserializer pair for each data type.
 
 XML schema features:
 	- abstract type name declarations
@@ -30,7 +30,7 @@ XML snippets features:
 	- field templates for each declared type
 	
 Folder ./bin contains example test.xml.sample schema and some sample snippets that could be useful to figure out how does it all works.
-Provided XML files in NOT real working examples but just test cases. You may vary XML snippets code and structure to achive various results and use particular any SDK or library you want.
+Provided XML files in NOT real working examples but just test cases. You may vary XML snippets code and structure to achieve various results and use particular any SDK or library you want.
 
 Requirements
 ------------


### PR DESCRIPTION
One commit contains some small fixes in the README while the other commit adds the -std=c++11 option.

When compiling with g++ (GCC) 4.8.2 20140120 (Red Hat 4.8.2-16) on Centos 7, I get the following error:
  src/protoc/ProtocData.cpp:423:7: warning: ‘auto’ changes meaning in C++11; please remove it
This can be solved by indicating to the compiler that you want C++11 compatibility with the -std=c++11 option.
